### PR TITLE
[fix][broker] Producer still publishes messages to Broker after Topic was unloaded

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -765,11 +765,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         return brokerService.checkTopicNsOwnership(getName())
                 .thenCompose(__ ->
                         incrementTopicEpochIfNeeded(producer, producerQueuedFuture))
-                .thenCompose(producerEpoch -> 
+                .thenCompose(producerEpoch ->
                         internalAddProducer(producer).thenApply(ignore -> {
                             USAGE_COUNT_UPDATER.incrementAndGet(this);
                             if (log.isDebugEnabled()) {
-                                log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(), 
+                                log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(),
                                         USAGE_COUNT_UPDATER.get(this));
                             }
                             return producerEpoch;
@@ -963,7 +963,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                 log.warn("[{}] Attempting to add producer to a terminated topic", topic);
                 throw new TopicTerminatedException("Topic was already terminated");
             }
-            
+
             if (isSameAddressProducersExceeded(producer)) {
                 log.warn("[{}] Attempting to add producer to topic which reached max same address producers limit",
                         topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
@@ -18,58 +18,157 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 import static org.testng.Assert.assertEquals;
-import java.util.concurrent.ConcurrentHashMap;
-import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.qos.AsyncTokenBucket;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+import com.google.common.collect.ImmutableMap;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.broker.service.nonpersistent.NonPersistentSubscription;
+import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.api.proto.ProducerAccessMode;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.protocol.schema.SchemaVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
-public class AbstractTopicTest {
-    private AbstractSubscription subscription;
-    private AbstractTopic topic;
+public class AbstractTopicTest extends BrokerTestBase {
 
-    @BeforeMethod
-    public void beforeMethod() {
-        BrokerService brokerService = mock(BrokerService.class);
-        PulsarService pulsarService = mock(PulsarService.class);
-        ServiceConfiguration serviceConfiguration = mock(ServiceConfiguration.class);
-        BacklogQuotaManager backlogQuotaManager = mock(BacklogQuotaManager.class);
-        subscription = mock(AbstractSubscription.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractTopicTest.class);
 
-        when(brokerService.pulsar()).thenReturn(pulsarService);
-        doReturn(pulsarService).when(brokerService).getPulsar();
-        when(pulsarService.getConfiguration()).thenReturn(serviceConfiguration);
-        when(brokerService.getBacklogQuotaManager()).thenReturn(backlogQuotaManager);
-        doReturn(AsyncTokenBucket.DEFAULT_SNAPSHOT_CLOCK).when(pulsarService).getMonotonicClock();
-
-        topic = mock(AbstractTopic.class, withSettings()
-                .useConstructor("topic", brokerService)
-                .defaultAnswer(CALLS_REAL_METHODS));
-
-        final var subscriptions = new ConcurrentHashMap<String, Subscription>();
-        subscriptions.put("subscription", subscription);
-        when(topic.getSubscriptions()).thenAnswer(invocation -> subscriptions);
+    @DataProvider(name = "topicAndSubscription")
+    public Object[][] topicAndSubscriptionProvider() {
+        Supplier<Pair<AbstractTopic, AbstractSubscription>> persistentProvider =
+                createProvider(TopicDomain.persistent, PersistentSubscription.class);
+        Supplier<Pair<AbstractTopic, AbstractSubscription>> nonPersistentProvider =
+                createProvider(TopicDomain.non_persistent, NonPersistentSubscription.class);
+        return new Object[][]{{persistentProvider}, {nonPersistentProvider}};
     }
 
-    @Test
-    public void testGetMsgOutCounter() {
+    private Supplier<Pair<AbstractTopic, AbstractSubscription>> createProvider(
+            TopicDomain topicDomain, Class<? extends AbstractSubscription> subscriptionClass) {
+        return () -> {
+            String topicName = topicDomain.value() + "://public/default/topic-0";
+            try {
+                admin.topics().createNonPartitionedTopic(topicName);
+            } catch (PulsarAdminException e) {
+                throw new RuntimeException("Create Topic failed", e);
+            }
+            Optional<Topic> topicOpt = pulsar.getBrokerService()
+                    .getTopicReference(topicName);
+            if (topicOpt.isEmpty()) {
+                throw new RuntimeException("Topic " + topicName + " not found");
+            }
+            Topic topic = spy(topicOpt.get());
+            AbstractSubscription subscription = mock(subscriptionClass);
+            doReturn(ImmutableMap.of("subscription", subscription))
+                    .when(topic).getSubscriptions();
+            return Pair.of((AbstractTopic) topic, subscription);
+        };
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.setupDefaultTenantAndNamespace();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(dataProvider = "topicAndSubscription")
+    public void testGetMsgOutCounter(Supplier<Pair<AbstractTopic, AbstractSubscription>> provider) {
+        Pair<AbstractTopic, AbstractSubscription> topicAndSubscription = provider.get();
+        AbstractTopic topic = topicAndSubscription.getLeft();
+        AbstractSubscription subscription = topicAndSubscription.getRight();
         topic.msgOutFromRemovedSubscriptions.add(1L);
         when(subscription.getMsgOutCounter()).thenReturn(2L);
         assertEquals(topic.getMsgOutCounter(), 3L);
     }
 
-    @Test
-    public void testGetBytesOutCounter() {
+    @Test(dataProvider = "topicAndSubscription")
+    public void testGetBytesOutCounter(Supplier<Pair<AbstractTopic, AbstractSubscription>> provider) {
+        Pair<AbstractTopic, AbstractSubscription> topicAndSubscription = provider.get();
+        AbstractTopic topic = topicAndSubscription.getLeft();
+        AbstractSubscription subscription = topicAndSubscription.getRight();
         topic.bytesOutFromRemovedSubscriptions.add(1L);
         when(subscription.getBytesOutCounter()).thenReturn(2L);
         assertEquals(topic.getBytesOutCounter(), 3L);
+    }
+
+    @Test(dataProvider = "topicAndSubscription")
+    public void testOverwriteOldProducerAfterTopicClosed(
+            Supplier<Pair<AbstractTopic, AbstractSubscription>> provider) throws InterruptedException {
+        Pair<AbstractTopic, AbstractSubscription> topicAndSubscription = provider.get();
+        AbstractTopic topic = topicAndSubscription.getLeft();
+        Producer oldProducer = spy(createProducer(topic));
+        ServerCnx oldCnx = spy((ServerCnx) oldProducer.getCnx());
+        doReturn(oldCnx).when(oldProducer).getCnx();
+
+        // Add old producer
+        topic.addProducer(oldProducer, new CompletableFuture<>()).join();
+
+        CountDownLatch oldCnxCheckInvokedLatch = new CountDownLatch(1);
+        CountDownLatch oldCnxCheckStartLatch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            CompletableFuture<Optional<Boolean>> future = new CompletableFuture<>();
+            CompletableFuture.runAsync(() -> {
+                try {
+                    oldCnxCheckInvokedLatch.countDown();
+                    oldCnxCheckStartLatch.await();
+                } catch (InterruptedException e) {
+                    future.completeExceptionally(e);
+                }
+                future.complete(Optional.of(false));
+            });
+            return future;
+        }).when(oldCnx).checkConnectionLiveness();
+
+        // Add new producer
+        Producer newProducer = createProducer(topic);
+        CompletableFuture<Optional<Long>> producerEpoch =
+                topic.addProducer(newProducer, new CompletableFuture<>());
+
+        oldCnxCheckInvokedLatch.await();
+        topic.close(true);
+        // Run pending tasks to remove old producer from topic.
+        ((EmbeddedChannel) oldCnx.ctx().channel()).runPendingTasks();
+        oldCnxCheckStartLatch.countDown();
+        try {
+            producerEpoch.join();
+            fail("TopicFencedException expected");
+        } catch (CompletionException e) {
+            LOG.error("Failed to add producer", e);
+            assertEquals(e.getCause().getClass(), BrokerServiceException.TopicFencedException.class);
+        }
+    }
+
+    private Producer createProducer(Topic topic) {
+        ServerCnx serverCnx = new ServerCnx(pulsar);
+        new EmbeddedChannel(serverCnx);
+        assertNotNull(serverCnx.ctx());
+        return new Producer(topic, serverCnx, 1, "prod-name",
+                "app-0", false, null, SchemaVersion.Latest, 0, false,
+                ProducerAccessMode.Shared, Optional.empty(), true);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
-import com.google.common.collect.ImmutableMap;
 import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -77,7 +77,7 @@ public class AbstractTopicTest extends BrokerTestBase {
             }
             Topic topic = spy(topicOpt.get());
             AbstractSubscription subscription = mock(subscriptionClass);
-            doReturn(ImmutableMap.of("subscription", subscription))
+            doReturn(Map.of("subscription", subscription))
                     .when(topic).getSubscriptions();
             return Pair.of((AbstractTopic) topic, subscription);
         };
@@ -127,7 +127,7 @@ public class AbstractTopicTest extends BrokerTestBase {
 
         // Add old producer
         topic.addProducer(oldProducer, new CompletableFuture<>()).join();
-        
+
         CountDownLatch oldCnxCheckInvokedLatch = new CountDownLatch(1);
         CountDownLatch oldCnxCheckStartLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
@@ -151,14 +151,14 @@ public class AbstractTopicTest extends BrokerTestBase {
 
         // Wait until new producer entered `AbstractTopic#tryOverwriteOldProducer`
         oldCnxCheckInvokedLatch.await();
-        
+
         topic.close(true);
         // Run pending tasks to remove old producer from topic.
         ((EmbeddedChannel) oldCnx.ctx().channel()).runPendingTasks();
-        
+
         // Unblock ServerCnx#checkConnectionLiveness to resume `AbstractTopic#tryOverwriteOldProducer`
         oldCnxCheckStartLatch.countDown();
-        
+
         // As topic is fenced, adding new producer should fail.
         try {
             producerEpoch.join();


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #24792

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

After unloading a bundle with many non-persistent topics from Broker, we found some producers in `ProducerAccessMode.Shared` mode were still publishing messages to the broker. Even thought the topic was not loaded by the broker any more.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Run [AbstractTopicTest#testOverwriteOldProducerAfterTopicClosed](https://github.com/apache/pulsar/blob/8c6eb0c5d1541d49451cecfa2af43cef71def416/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java#L120)

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
